### PR TITLE
Fix links to point to the newer location of Pantheon App's documentation

### DIFF
--- a/static/error_400.html
+++ b/static/error_400.html
@@ -43,7 +43,7 @@
 						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox">Kalabox Readme</a>
 					</div>
 					<div class="btn-wrapper">
-						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox/wiki/Pantheon-Guide">Pantheon Starter Guide</a>
+						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox-app-pantheon">Pantheon Starter Guide</a>
 					</div>
 				</div>
 

--- a/static/error_502.html
+++ b/static/error_502.html
@@ -45,7 +45,7 @@
 						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox">Kalabox Readme</a>
 					</div>
 					<div class="btn-wrapper">
-						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox/wiki/Pantheon-Guide">Pantheon Starter Guide</a>
+						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox-app-pantheon">Pantheon Starter Guide</a>
 					</div>
 				</div>
 

--- a/static/error_504.html
+++ b/static/error_504.html
@@ -46,7 +46,7 @@
 						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox">Kalabox Readme</a>
 					</div>
 					<div class="btn-wrapper">
-						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox/wiki/Pantheon-Guide">Pantheon Starter Guide</a>
+						<a class="btn btn-primary" href="https://github.com/kalabox/kalabox-app-pantheon">Pantheon Starter Guide</a>
 					</div>
 				</div>
 

--- a/static/error_default.html
+++ b/static/error_default.html
@@ -46,7 +46,7 @@
             <a class="btn btn-primary" href="https://github.com/kalabox/kalabox">Kalabox Readme</a>
           </div>
           <div class="btn-wrapper">
-            <a class="btn btn-primary" href="https://github.com/kalabox/kalabox/wiki/Pantheon-Guide">Pantheon Starter Guide</a>
+            <a class="btn btn-primary" href="https://github.com/kalabox/kalabox-app-pantheon">Pantheon Starter Guide</a>
           </div>
         </div>
 


### PR DESCRIPTION
I'm using https://github.com/kalabox/kalabox-app-pantheon/ as the "Pantheon Starter Guide" destination, if this is incorrect feel free to change it or let me know and I'll change it.

This should close (or at least advance the closing) of #654.
